### PR TITLE
Add help strings for the admin account in the install form

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -42,11 +42,15 @@ ram.runtime = "50M"
     [install.admin]
     # this is a generic question - ask strings are automatically handled by YunoHost's core
     type = "user"
+    help.en = "The email address of this user will be used as the admin login for Linkstack"
+    help.fr = "L'adresse e-mail associée à cet utilisateur sera utilisée comme identifiant administrateur dans Linkstack"
 
     [install.password]
     # this is a generic question - ask strings are automatically handled by YunoHost's core
     # Note that user-provided passwords questions are not automatically saved as setting
     type = "password"
+    help.en = "The password for the Linkstack admin user"
+    help.fr = "Le mot de passe pour le compte administrateur de Linkstack"
 
 [resources]
     # See the packaging documentation for the full set

--- a/manifest.toml
+++ b/manifest.toml
@@ -16,7 +16,7 @@ admindoc = "https://docs.linkstack.org/"
 code = "https://github.com/LinkStackOrg/LinkStack"
 # XXX: No CPE yet... check https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=LinkStack
 #cpe = "???"
-fund = "https://liberapay.com/LittleLink-Custom"
+fund = "https://liberapay.com/LinkStack"
 
 [integration]
 yunohost = ">= 11.2"
@@ -42,15 +42,15 @@ ram.runtime = "50M"
     [install.admin]
     # this is a generic question - ask strings are automatically handled by YunoHost's core
     type = "user"
-    help.en = "The email address of this user will be used as the admin login for Linkstack"
-    help.fr = "L'adresse e-mail associée à cet utilisateur sera utilisée comme identifiant administrateur dans Linkstack"
+    help.en = "The email address of this user will be used as the admin login for LinkStack"
+    help.fr = "L'adresse e-mail associée à cet utilisateur sera utilisée comme identifiant administrateur dans LinkStack"
 
     [install.password]
     # this is a generic question - ask strings are automatically handled by YunoHost's core
     # Note that user-provided passwords questions are not automatically saved as setting
     type = "password"
-    help.en = "The password for the Linkstack admin user"
-    help.fr = "Le mot de passe pour le compte administrateur de Linkstack"
+    help.en = "The password for the LinkStack admin user"
+    help.fr = "Le mot de passe pour le compte administrateur de LinkStack"
 
 [resources]
     # See the packaging documentation for the full set


### PR DESCRIPTION
## Problem

- admin logins are not obvious
see: https://forum.yunohost.org/t/how-to-access-app-admin-panels-of-jellyfin-and-linkstack/28460

## Solution

- add help strings for the admin account in the install form

![a screenshot of the help strings](https://github.com/YunoHost-Apps/linkstack_ynh/assets/6963387/b0fdcadc-1b24-435b-9f64-f1311b602ced)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
